### PR TITLE
[REVIEW]: Fix typos in docstrings

### DIFF
--- a/examples/mixing_problems/2-multiple_tanks.py
+++ b/examples/mixing_problems/2-multiple_tanks.py
@@ -91,7 +91,7 @@ connectors = [
 """
 Now we just need to define our system of tanks. Compared to the single tank example, 
 the children, variable ports and input ports are exactly the same (just one for each tank, 
-if it was specified), except for aditionally the specification of the flow rates `rate_i_j` 
+if it was specified), except for additionally the specification of the flow rates `rate_i_j` 
 of the connector pipes as additional input ports.
 
 The directed wires simply connect the rates at the input ports to the correct pipes.

--- a/examples/population_dynamics/2-logistic_population.py
+++ b/examples/population_dynamics/2-logistic_population.py
@@ -84,8 +84,8 @@ apparent advantages:
     (3) The object as a whole has a clean form: it is an object depending on input parameters "r" and "K",
         and makes the variable "x" available to the wider system.
 
-Fortuntately, composite objects in psymple allow for all of these to be implemented, and this is how
-psymple is intended to be used in best practice to allow for full modularity and resuability. To achieve this,
+Fortunately, composite objects in psymple allow for all of these to be implemented, and this is how
+psymple is intended to be used in best practice to allow for full modularity and reusablity. To achieve this,
 composite objects can be given their own ports: input ports to read parameters or specify default values, and
 variable ports to expose variables and their differential equations for composition. These ports connect to 
 wires in the ways we've already seen.

--- a/psymple/variables.py
+++ b/psymple/variables.py
@@ -185,7 +185,7 @@ class SimVariable(Variable):
             print_vars_dict: a mapping between `sympy.Symbol` objects to use for the readout
             print_pars_dict: a mapping between `sympy.Symbol` objects to use for the readout
             type: the format of the output. By default, this is a string. Specifying `"latex"`
-                prouces a `LaTeX`-compilable output.
+                produces a `LaTeX`-compilable output.
 
         """
         print_symbol = print_vars_dict[self.symbol]
@@ -274,7 +274,7 @@ class SimParameter(Parameter):
             print_vars_dict: a mapping between `sympy.Symbol` objects to use for the readout
             print_pars_dict: a mapping between `sympy.Symbol` objects to use for the readout
             type: the format of the output. By default, this is a string. Specifying `"latex"`
-                prouces a `LaTeX`-compilable output.
+                produces a `LaTeX`-compilable output.
 
         """
         print_symbol = print_pars_dict[self.symbol]


### PR DESCRIPTION
Dear authors, 

This PR fixes a few typos in docstrings.

REVIRE ISSUE: https://github.com/openjournals/joss-reviews/issues/7364#issuecomment-2422152903