### PR TITLE
vpo rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,7 +170,6 @@ psymple/functions.py
 psymple/population_dynamics/
 psymple/io/
 psymple/unused_ported_objects/
-psymple
 doctest_runner.py
 test_json.json
 examples/mixing_problems/3-state_dependent_rates.py

--- a/docs/examples/second_order_odes/three_body_problem.md
+++ b/docs/examples/second_order_odes/three_body_problem.md
@@ -73,6 +73,7 @@ class velocity(CompositePortedObject):
             children=[vars, force, dist],
             input_ports=["x", "y", "x_o", "y_o", "m_o"],
             variable_ports=["v_x", "v_y"],
+            output_ports=["v_x", "v_y"],
             directed_wires=[
                 ("m_o", "force.m"),
                 ("x", "dist.x"),
@@ -83,6 +84,8 @@ class velocity(CompositePortedObject):
                 ("dist.Del_y", "vars.Del_y"),
                 ("dist.d", "force.d"),
                 ("force.mu", "vars.mu"),
+                ("vars.v_x", "v.x"),
+                ("vars.v_y", "v.y"),
             ],
             variable_wires=[
                 (["vars.v_x"], "v_x"),

--- a/examples/second_order_ODEs/2-three_body_problem.py
+++ b/examples/second_order_ODEs/2-three_body_problem.py
@@ -46,6 +46,7 @@ class velocity(CompositePortedObject):
             children=[vars, force, dist],
             input_ports=["x", "y", "x_o", "y_o", "m_o"],
             variable_ports=["v_x", "v_y"],
+            output_ports=["v_x", "v_y"],
             directed_wires=[
                 ("m_o", "force.m"),
                 ("x", "dist.x"),
@@ -56,6 +57,8 @@ class velocity(CompositePortedObject):
                 ("dist.Del_y", "vars.Del_y"),
                 ("dist.d", "force.d"),
                 ("force.mu", "vars.mu"),
+                ("vars.v_x", "v_x"),
+                ("vars.v_y", "v_y"),
             ],
             variable_wires=[
                 (["vars.v_x"], "v_x"),

--- a/psymple/abstract.py
+++ b/psymple/abstract.py
@@ -80,11 +80,13 @@ class Assignment(ABC):
         self.symbol_wrapper = SymbolWrapper(symbol)
         self.expression_wrapper = ExpressionWrapper(expression, parsing_locals)
 
-    def substitute_symbol(self, old_symbol, new_symbol):
+    def substitute_symbol(self, old_symbol, new_symbol, sub_symbol = True, sub_expression = True):
         # Substitutes the symbol inside self.symbol_wrapper with new_symbol
-        if self.symbol == old_symbol:
-            self.symbol = new_symbol
-        self.expression = self.expression.subs(old_symbol, new_symbol)
+        if sub_symbol:
+            if self.symbol == old_symbol:
+                self.symbol = new_symbol
+        if sub_expression:
+            self.expression = self.expression.subs(old_symbol, new_symbol)
 
     def get_free_symbols(self, global_symbols=set([Symbol("T")])):
         # Returns all the symbols of self.expression which are not the symbol wrapper or time symbol

--- a/psymple/build/assignments.py
+++ b/psymple/build/assignments.py
@@ -81,8 +81,9 @@ class ParameterAssignment(Assignment):
                 self.expression,
                 self.symbol_wrapper.description,
             )
-        # We forbid the symbol wrapper to appear in the expression eg. R=2*R
-        if self.symbol in self.expression.free_symbols:
+        # We forbid the symbol wrapper to appear in the expression eg. R=2*R unless the expression
+        # and symbol are identical
+        if (self.symbol in self.expression.free_symbols) and (self.symbol != self.expression):
             raise DependencyError(
                 f"The symbol {self.symbol} cannot appear as both the function "
                 f"value and argument of {self}."
@@ -94,8 +95,8 @@ class ParameterAssignment(Assignment):
     def _sync_param_value(self):
         self.parameter.value = self.expression
 
-    def substitute_symbol(self, old_symbol, new_symbol):
-        super().substitute_symbol(old_symbol, new_symbol)
+    def substitute_symbol(self, old_symbol, new_symbol, sub_symbol, sub_expression):
+        super().substitute_symbol(old_symbol, new_symbol, sub_symbol, sub_expression)
         self._sync_param_value()
 
     @property

--- a/psymple/build/compiled_ports.py
+++ b/psymple/build/compiled_ports.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 from .assignments import (
     Assignment,
+    ParameterAssignment,
 )
 
 from .ports import (
@@ -30,14 +31,17 @@ class CompiledPort(Port):
         self.assignment = deepcopy(assignment)
         self.description = port.description
 
-    def substitute_symbol(self, old_symbol, new_symbol):
+    def substitute_symbol(self, old_symbol, new_symbol, sub_output_symbol = True, sub_expression = True):
         if self.assignment:
-            self.assignment.substitute_symbol(old_symbol, new_symbol)
+            sub_symbol = True
+            if isinstance(self.assignment, ParameterAssignment):
+                sub_symbol = sub_output_symbol
+            self.assignment.substitute_symbol(old_symbol, new_symbol, sub_symbol, sub_expression)
             # In case the symbol of this port itself was substituted,
             # this will be reflected in the assignment, and we can pull
             # the updated name from there.
             self.name = self.assignment.name
-        else:
+        elif sub_output_symbol:
             assert isinstance(old_symbol, sym.Symbol)
             assert isinstance(new_symbol, sym.Symbol)
             assert isinstance(self.symbol, sym.Symbol)

--- a/psymple/build/system.py
+++ b/psymple/build/system.py
@@ -716,13 +716,15 @@ class System(FunctionHandler, SetterObject):
         G.add_nodes_from(parameter_symbols)
         for parameter in self.parameters.values():
             parsym = parameter.symbol
-            for dependency in parameter.dependent_parameters:
-                if dependency in parameter_symbols:
-                    G.add_edge(dependency, parsym)
-                elif dependency not in (variable_symbols | {self.time.symbol}):
-                    raise SystemError(
-                        f"Parameter {parsym} references undefined symbol {dependency}"
-                    )
+            if parsym != parameter.expression:
+                # Skip identity parameters
+                for dependency in parameter.dependent_parameters:
+                    if dependency in parameter_symbols:
+                        G.add_edge(dependency, parsym)
+                    elif dependency not in (variable_symbols | {self.time.symbol}):
+                        raise SystemError(
+                            f"Parameter {parsym} references undefined symbol {dependency}"
+                        )
         try:
             nodes = list(nx.topological_sort(G))
         except nx.exception.NetworkXUnfeasible:

--- a/psymple/build/wires.py
+++ b/psymple/build/wires.py
@@ -20,7 +20,7 @@ class SymbolIdentification:
         self.new_symbol = new_symbol
 
     def __repr__(self):
-        return f"SymbolIdentification {self.new_symbol} = {self.old_symbol}"
+        return f"SymbolIdentification {self.old_symbol} -> {self.new_symbol}"
 
 class VariableAggregationWiring:
     """

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -58,14 +58,16 @@ class TestCreation(unittest.TestCase):
         self.assertEqual(symbol_wrapper.symbol, sym.Symbol("x"))
 
     def test_parameter_assignment_error(self):
-        # Parameter assignments cannot have their symbol appearing in expressions
+        # Parameter assignments cannot have their symbol appearing in expressions unless it is an identity
         # but assignment and differential assignment can.
 
         with self.assertRaises(DependencyError):
             assg_1 = ParameterAssignment("x", "r*x")
 
-        assg_2 = Assignment("x", "r*x")
-        assg_3 = DifferentialAssignment("x", "r*x")
+        assg_2 = ParameterAssignment("x", "x")
+
+        assg_3 = Assignment("x", "r*x")
+        assg_4 = DifferentialAssignment("x", "r*x")
 
 class TestHandling(unittest.TestCase):
     def test_symbol_substitution(self):

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -169,6 +169,7 @@ class TestCompilation(unittest.TestCase):
         vpo = VariablePortedObject(
             name="growth",
             assignments=[("x", "r*x")],
+            create_output_ports=False,
         )
 
         cpo = CompositePortedObject(
@@ -217,6 +218,7 @@ class TestCompilation(unittest.TestCase):
         vpo = VariablePortedObject(
             name="growth",
             assignments=[("x", "r*x")],
+            create_output_ports=False,
         )
 
         cpo = CompositePortedObject(


### PR DESCRIPTION
This update brings variable ported objects structurally in-line with resource sharers, addressing #69. Specifically, it implements resource sharers with identity observation functions. Different observation functions will be allowed in future updates.

It revokes the changes and suggested changes of #67 and #68. The wiring systems of parameters and variables are now structurally separate.

### Summary of changes

- Variable ported objects can now create an output port for every exposed variable they create. This output port carries an identity function for the variable of the same name which can be connected to by a directed wire like any other output port.
- Directed wires cannot be connected to any variable ports.
- There are no changes to the syntax, behaviour, or restrictions of variable wires.
- The requested changes of #67 and #68 are possible by extending the directed wiring of a system, for which there are no additional restrictions than those outlined above.